### PR TITLE
Simple fix for empty property and empty inline dataview problem

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "graph-link-types",
 	"name": "Graph Link Types",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"minAppVersion": "1.5.0",
 	"description": "Link types for graph view.",
 	"author": "natefrisch01",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "graph-link-types",
-	"version": "0.1.2",
+	"version": "0.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "graph-link-types",
-	"version": "0.1.2",
+	"version": "0.3.2",
 	"description": "Link types for Obsidian graph view.",
 	"main": "main.js",
 	"scripts": {

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -425,6 +425,10 @@ export class LinkManager {
         if (!sourcePage) return null;
 
         for (const [key, value] of Object.entries(sourcePage)) {
+			// Skip empty values 
+			if (value === null || value === undefined || value === '') {
+            	continue;
+        	}
             const valueType = this.determineDataviewLinkType(value);
 
             switch (valueType) {


### PR DESCRIPTION
just add a quick check. 

tested on my old vault and new vault with only Graph-Link-Types and Dataview.

before
<img width="944" alt="image" src="https://github.com/natefrisch01/Graph-Link-Types/assets/17292215/e6e0c650-5bf1-49be-b1b9-a9c0bf4df31b">

after
<img width="1269" alt="image" src="https://github.com/natefrisch01/Graph-Link-Types/assets/17292215/efdf4c13-68b1-4edc-9b69-bb6d63420d71">
