### PR TITLE
Do not stop checking DataView properties on first failure

### DIFF
--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -459,10 +459,11 @@ export class LinkManager {
                     }
                     break;
                 default:
-                    //metadata is not a link, return null
-                    return null;
+                  // We will continue to check other DataView properties
+                  continue
             }
         }
+        // If no DataView properties match, we consider that metadata key does not exist
         return null;
     }
 

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -460,7 +460,7 @@ export class LinkManager {
                     break;
                 default:
                   // We will continue to check other DataView properties
-                  continue
+                  break;
             }
         }
         // If no DataView properties match, we consider that metadata key does not exist

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -459,8 +459,8 @@ export class LinkManager {
                     }
                     break;
                 default:
-                  // We will continue to check other DataView properties
-                  break;
+				    // We will continue to check other DataView properties
+				    break;
             }
         }
         // If no DataView properties match, we consider that metadata key does not exist


### PR DESCRIPTION
A small fix for the following situation:

```
[what_is_this:: not_a_link]
[what_is_that:: [[that_is_a_link]]]
```

When iterating through the DataView properties, previously, the code would see that the metadata property `what_is_this` is not a link and would stop immediately. If we allow for it to continue, instead of stopping, it will check `what_is_that` property, return it as intended and render the link correctly.

The fix here allows for consideration across all DataView properties, as such, we can have DataView properties with a link and ones without a link together.