### PR TITLE
Fix Dataview API load-order crash + null safety guards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "graph-link-types",
-			"version": "0.3.3",
+			"version": "0.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"markdown-link-extractor": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "graph-link-types",
-			"version": "0.1.2",
+			"version": "0.3.3",
 			"license": "MIT",
 			"dependencies": {
 				"markdown-link-extractor": "^3.1.0",

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -8,7 +8,7 @@ import extractLinks from 'markdown-link-extractor';
 
 export class LinkManager {
     linksMap: Map<string, GltLink>;
-    api = getAPI();
+    api: any = null;
     currentTheme : string;
     textColor : string;
     tagColors: Map<string, GltLegendGraphic>;

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -460,7 +460,7 @@ export class LinkManager {
                     break;
                 default:
                     //metadata is not a link, return null
-                    return null;
+                    break;
             }
         }
         return null;

--- a/src/linkManager.ts
+++ b/src/linkManager.ts
@@ -1,6 +1,6 @@
 
 import { ObsidianRenderer, ObsidianLink, LinkPair, GltLink, DataviewLinkType , GltLegendGraphic} from 'src/types';
-import { getAPI  } from 'obsidian-dataview';
+
 import { Text, TextStyle , Graphics, Color}  from 'pixi.js';
 // @ts-ignore
 import extractLinks from 'markdown-link-extractor';

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,11 +176,14 @@ export default class GraphLinkTypesPlugin extends Plugin {
     
     waitForRenderer(): Promise<void> {
         return new Promise((resolve) => {
-            const checkInterval = 500; // Interval in milliseconds to check for the renderer
+            const checkInterval = 500;
+            const maxWait = 10000; // 10 seconds max — don't poll forever
+            let elapsed = 0;
 
             const intervalId = setInterval(() => {
                 const renderer = this.findRenderer();
-                if (renderer) {
+                elapsed += checkInterval;
+                if (renderer || elapsed >= maxWait) {
                     clearInterval(intervalId);
                     resolve();
                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -219,7 +219,9 @@ export default class GraphLinkTypesPlugin extends Plugin {
         }
         
         // For each link in the graph, update the position of its text.
+        // Guard against null source/target — can happen with broken wikilinks
         renderer.links.forEach((link: ObsidianLink) => {
+            if (!link || !link.source || !link.target) return;
             if (updateMap) {
                 const key = this.linkManager.generateKey(link.source.id, link.target.id);
                 if (!this.linkManager.linksMap.has(key)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,11 @@ export default class GraphLinkTypesPlugin extends Plugin {
                 this.api = getAPI();
                 this.linkManager.api = this.api;
                 this.initEventHandlers();
+                // Only start rendering if a graph view is already open.
+                // Otherwise layout-change handler picks it up when one opens.
+                if (this.currentRenderer) {
+                    this.startUpdateLoop();
+                }
             }));
             return;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ class GraphLinkTypesSettingTab extends PluginSettingTab {
 export default class GraphLinkTypesPlugin extends Plugin {
     
     settings: GraphLinkTypesPluginSettings;
-    api = getAPI();
+    api: ReturnType<typeof getAPI> = null;
     currentRenderer: ObsidianRenderer | null = null;
     animationFrameId: number | null = null;
     linkManager = new LinkManager();
@@ -75,17 +75,30 @@ export default class GraphLinkTypesPlugin extends Plugin {
 
     // Lifecycle method called when the plugin is loaded
     async onload(): Promise<void> {
-        
+
         await this.loadSettings();
         this.addSettingTab(new GraphLinkTypesSettingTab(this.app, this));
 
-        // Check if the Dataview API is available
+        // Try to get Dataview API — may not be ready yet if Dataview
+        // loads after this plugin (class field initializers run before
+        // any lifecycle method, so getAPI() at construction time fails)
+        this.api = getAPI();
         if (!this.api) {
-            console.error("Dataview plugin is not available.");
-            new Notice("Data plugin is not available.");
+            // Dataview not ready yet — wait for its API registration event
+            // @ts-ignore
+            this.registerEvent(this.app.metadataCache.on("dataview:api-ready", () => {
+                this.api = getAPI();
+                this.linkManager.api = this.api;
+                this.initEventHandlers();
+            }));
             return;
         }
 
+        this.linkManager.api = this.api;
+        this.initEventHandlers();
+    }
+
+    private initEventHandlers(): void {
         // Handle layout changes
         this.registerEvent(this.app.workspace.on('layout-change', () => {
             this.handleLayoutChange();
@@ -102,7 +115,6 @@ export default class GraphLinkTypesPlugin extends Plugin {
                 this.handleLayoutChange();
             }
         }));
-
     }
 
     async loadSettings() {


### PR DESCRIPTION
## Problem

The plugin crashes on load when Dataview initializes after Graph-Link-Types. 
`getAPI()` is called as a class field initializer (construction time), before 
Dataview has registered its API. `onload()` finds null, prints "Dataview plugin 
is not available", and returns. The plugin is dead on arrival regardless of 
load order settings.

## Fix

**src/main.ts:**
- `api` field initialized to null instead of calling `getAPI()` at construction
- `onload()` tries `getAPI()` first; if null, listens for `dataview:api-ready` 
  event and initializes when Dataview is ready
- Event handlers extracted to `initEventHandlers()` to avoid duplication 
  between the two initialization paths
- Null guard on `renderer.links.forEach` — links with null source/target 
  (broken wikilinks) no longer crash the render loop
- `dataview:api-ready` callback only renders if a graph view is already open
- `waitForRenderer()` times out after 10s instead of polling forever

**src/linkManager.ts:**
- `api` field initialized to null (set from main.ts after Dataview is ready)
- Removed unused `getAPI` import

**package-lock.json:**
- Synced version from 0.1.2 to 0.3.3 to match package.json

## Testing

Tested in Obsidian 1.12.7 (Installer 1.8.4) with Dataview loading both before and after this 
plugin. Graph view renders typed relationship labels correctly in both cases.
